### PR TITLE
Skip checking attributes of data.table indices

### DIFF
--- a/tests/testthat/test-policy_data.R
+++ b/tests/testthat/test-policy_data.R
@@ -257,7 +257,7 @@ test_that("policy_data melts wide data correctly in a two stage case.", {
     baseline = "B",
     utility = "outcome"
   )
-  expect_equal(pd$stage_data, target_stage_data)
+  expect_equal(pd$stage_data, target_stage_data, check.attributes = FALSE)
 
   # including deterministic rewards:
   wide_data <- data.table(
@@ -300,7 +300,7 @@ test_that("policy_data melts wide data correctly in a two stage case.", {
     utility = c("outcome_1", "outcome_2", "outcome_3"),
     deterministic_rewards = list(U_A0 = c("outcome_1_A0", "outcome_2_A0"))
   )
-  expect_equal(pd$stage_data, target_stage_data)
+  expect_equal(pd$stage_data, target_stage_data, check.attributes = FALSE)
 
   # invalid inputs:
   args <- list(
@@ -356,7 +356,7 @@ test_that("policy_data melts wide data correctly in a single stage case.", {
 
   # except equal:
   pd <- policy_data(data = wide_data, action = "treat", covariates = c("B", "Z", "L"), utility = "outcome")
-  expect_equal(pd$stage_data, target_stage_data)
+  expect_equal(pd$stage_data, target_stage_data, check.attributes = FALSE)
   rm(pd)
 
   # duplicate variable names:
@@ -380,13 +380,15 @@ test_that("policy_data melts wide data correctly in a single stage case.", {
   )
   expect_equal(
     policy_data(data = wide_data_copy, action = "treat", covariates = c("B", "Z", "L"), utility = "outcome", id = "id")$stage_data,
-    target_stage_data
+    target_stage_data,
+    check.attributes = FALSE
   )
   wide_data_copy$id <- NULL
   wide_data_copy$ID <- c(1,2)
   expect_equal(
     policy_data(data = wide_data_copy, action = "treat", covariates = c("B", "Z", "L"), utility = "outcome", id = "ID")$stage_data,
-    target_stage_data
+    target_stage_data,
+    check.attributes = FALSE
   )
 
   #


### PR DESCRIPTION
https://github.com/Rdatatable/data.table/issues/6349

The development version of {data.table} has a new feature to improve internal sorting efficiency. A side effect of this is the exact structure of index objects (created by `setindex()`) changes slightly.

This breaks some {polle} tests which require more exactness than is maybe advisable. This simple PR turns off attribute checking; this might be too aggressive if there are important attributes that this is now ignoring. I lack the context to judge whether that might be the case.

We plan to release the next version of {data.table} to CRAN in roughly 2 weeks.